### PR TITLE
Add deploy job to CI workflow; switch to GitHub Actions Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Beautiful Jekyll CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Jekyll
@@ -34,3 +38,19 @@ jobs:
         run: bundle exec appraisal jekyll build --future --config _config_ci.yml,_config.yml
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The auto-generated pages-build-deployment workflow started failing Mar 21 because jekyll-build-pages:v1.0.13 uses the github-pages gem, which is incompatible with Beautiful Jekyll (Jekyll 4.x, no github-pages gem).

Add an explicit deploy job using actions/deploy-pages@v4 so the CI workflow handles both build and deployment. Add top-level permissions: contents: read with deploy-job-scoped pages: write + id-token: write per GitHub Actions best practice. Deploy only triggers on push to master, not PRs.

Requires GitHub Pages source to be set to "GitHub Actions" in repo settings.